### PR TITLE
Added support for auto incrementing last revision number in AssemblyInfo.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 [Oo]bj
 *.suo
 *.user
+/.vs
+/packages

--- a/WhenTheVersion.Tests/AssemblyInfoReaderTests.cs
+++ b/WhenTheVersion.Tests/AssemblyInfoReaderTests.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WhenTheVersion;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace WhenTheVersion.Tests
+{
+    [TestClass()]
+    public class AssemblyInfoReaderTests
+    {
+        string _projectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName;
+
+        [TestMethod()]
+        public void GetRevisionInfoTestCaseStraightForward()
+        {
+            AssemblyInfoReader assemblyInfoReader = new AssemblyInfoReader(Path.Combine(_projectDirectory, "AssemblyInfoTestCase1.cs"));
+            var revisionInfo = assemblyInfoReader.GetRevisionInfo();
+            //In this case it should not fail
+            Assert.AreEqual(true, revisionInfo.Succeed);
+        }
+
+
+        [TestMethod()]
+        public void GetRevisionInfoTestCaseWithAsterisks()
+        {
+            AssemblyInfoReader assemblyInfoReader = new AssemblyInfoReader(Path.Combine(_projectDirectory, "AssemblyInfoTestCase2.cs"));
+            var revisionInfo = assemblyInfoReader.GetRevisionInfo();
+            //In this case it should not succeed
+            Assert.AreEqual(true, !revisionInfo.Succeed);
+            
+        }
+
+        [TestMethod()]
+        public void GetRevisionInfoTestCaseWithComments()
+        {
+            AssemblyInfoReader assemblyInfoReader = new AssemblyInfoReader(Path.Combine(_projectDirectory, "AssemblyInfoTestCase3.cs"));
+            var revisionInfo = assemblyInfoReader.GetRevisionInfo();
+            //In this case it should succeed
+            Assert.AreEqual(true, revisionInfo.Succeed);
+            Assert.AreEqual(16, revisionInfo.NextRevisionNumber);
+        }
+
+
+        [TestMethod()]
+        public void GetRevisionInfoTestCaseMissingAssemblyVersionInfo()
+        {
+            AssemblyInfoReader assemblyInfoReader = new AssemblyInfoReader(Path.Combine(_projectDirectory, "AssemblyInfoTestCase4.cs"));
+            var revisionInfo = assemblyInfoReader.GetRevisionInfo();
+            //This needs to fail as file doesn't have AssemblyInfo line
+            Assert.AreEqual(false, revisionInfo.Succeed);
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void GetRevisionInfoTestCaseMissingFile()
+        {
+            AssemblyInfoReader assemblyInfoReader = new AssemblyInfoReader(Path.Combine(_projectDirectory, "AssemblyInfoTestCase6.cs"));
+            //This needs to throw FileNotFoundException
+            var revisionInfo = assemblyInfoReader.GetRevisionInfo();
+        }
+    }
+}

--- a/WhenTheVersion.Tests/AssemblyInfoTestCase1.cs
+++ b/WhenTheVersion.Tests/AssemblyInfoTestCase1.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e54a2b6f-998e-45e0-9329-8117e77e3067")]
+
+[assembly: AssemblyVersion("2019.6.20.0")]
+[assembly: AssemblyFileVersion("2019.6.20.0")]

--- a/WhenTheVersion.Tests/AssemblyInfoTestCase2.cs
+++ b/WhenTheVersion.Tests/AssemblyInfoTestCase2.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e54a2b6f-998e-45e0-9329-8117e77e3067")]
+
+[assembly: AssemblyVersion("2019.6.*")]
+[assembly: AssemblyFileVersion("2019.6.*")]

--- a/WhenTheVersion.Tests/AssemblyInfoTestCase3.cs
+++ b/WhenTheVersion.Tests/AssemblyInfoTestCase3.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e54a2b6f-998e-45e0-9329-8117e77e3067")]
+
+//[assembly: AssemblyVersion("2019.6.20.1")]  - This should not be used and next version should be 16
+//[assembly: AssemblyVersion("2019.6.20.12")] - This should not be used and next version should be 16
+
+[assembly: AssemblyVersion("2019.6.20.15")]
+[assembly: AssemblyFileVersion("2019.6.20.15")]

--- a/WhenTheVersion.Tests/AssemblyInfoTestCase4.cs
+++ b/WhenTheVersion.Tests/AssemblyInfoTestCase4.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e54a2b6f-998e-45e0-9329-8117e77e3067")]
+
+//[assembly: AssemblyVersion("2019.6.20.1")]  - This should not be used and next version should be 0
+//[assembly: AssemblyVersion("2019.6.20.12")] - This should not be used and next version should be 0

--- a/WhenTheVersion.Tests/Properties/AssemblyInfo.cs
+++ b/WhenTheVersion.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WhenTheVersion.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WhenTheVersion.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b8012fc7-6098-416c-a5da-ad266ca00030")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WhenTheVersion.Tests/WhenTheVersion.Tests.csproj
+++ b/WhenTheVersion.Tests/WhenTheVersion.Tests.csproj
@@ -1,0 +1,110 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B8012FC7-6098-416C-A5DA-AD266CA00030}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WhenTheVersion.Tests</RootNamespace>
+    <AssemblyName>WhenTheVersion.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="AssemblyInfoReaderTests.cs" />
+    <None Include="AssemblyInfoTestCase1.cs" />
+    <None Include="AssemblyInfoTestCase2.cs" />
+    <None Include="AssemblyInfoTestCase3.cs" />
+    <None Include="AssemblyInfoTestCase4.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WhenTheVersion\WhenTheVersion.csproj">
+      <Project>{2cacb06c-1f98-4938-a333-92eba724cef9}</Project>
+      <Name>WhenTheVersion</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/WhenTheVersion.Tests/packages.config
+++ b/WhenTheVersion.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net46" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net46" />
+</packages>

--- a/WhenTheVersion.sln
+++ b/WhenTheVersion.sln
@@ -1,7 +1,11 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29009.5
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhenTheVersion", "WhenTheVersion\WhenTheVersion.csproj", "{2CACB06C-1F98-4938-A333-92EBA724CEF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhenTheVersion.Tests", "WhenTheVersion.Tests\WhenTheVersion.Tests.csproj", "{B8012FC7-6098-416C-A5DA-AD266CA00030}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,8 +23,19 @@ Global
 		{2CACB06C-1F98-4938-A333-92EBA724CEF9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2CACB06C-1F98-4938-A333-92EBA724CEF9}.Release|x86.ActiveCfg = Release|x86
 		{2CACB06C-1F98-4938-A333-92EBA724CEF9}.Release|x86.Build.0 = Release|x86
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Debug|x86.Build.0 = Debug|Any CPU
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Release|x86.ActiveCfg = Release|Any CPU
+		{B8012FC7-6098-416C-A5DA-AD266CA00030}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8DC6B4A4-B8E9-43BD-949D-9F1201181102}
 	EndGlobalSection
 EndGlobal

--- a/WhenTheVersion/AssemblyInfoReader.cs
+++ b/WhenTheVersion/AssemblyInfoReader.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace WhenTheVersion
+{
+    public class AssemblyInfoReader
+    {
+        private readonly string _fileNameWithPath;
+
+        public AssemblyInfoReader(string fileNameWithPath)
+        {
+            _fileNameWithPath = fileNameWithPath;
+        }
+
+        public RevisionInfo GetRevisionInfo()
+        {
+            if (File.Exists(_fileNameWithPath) == false)
+                throw new FileNotFoundException(_fileNameWithPath);
+
+            //AsseemblyInfo file will be just couple of lines so no harm in reading entire file
+            var fileContents = RemoveAllComments(File.ReadAllText(_fileNameWithPath));
+
+            if (string.IsNullOrWhiteSpace(fileContents))
+                return new RevisionInfo(0, 0, "File contents are empty");
+
+            const string GROUP_VERSION_NUMBER = "VersionNumber";
+
+            Regex extractAssemblyVersionLine = new Regex($@"Assembly(File)?Version\(""(?<{GROUP_VERSION_NUMBER}>.*)""\)"); //It will be case sensitive search
+
+            Match lineMatch = extractAssemblyVersionLine.Match(fileContents); //Grab the first match only
+
+            if (lineMatch.Success == false)
+                return new RevisionInfo(0, 0, "Can't find any line with text 'AssemblyFileVersion' or 'AssemblyVersion'");
+
+            var versionNumber = lineMatch.Groups[GROUP_VERSION_NUMBER].Value;
+            var lastRevisionNumber = versionNumber.Split('.').LastOrDefault();
+
+            if (int.TryParse(lastRevisionNumber, out var lastNumber))
+                return new RevisionInfo(lastNumber, lastNumber + 1);
+
+            return new RevisionInfo(0, 0, $"Can't parse {lastRevisionNumber} to int");
+        }
+        string RemoveAllComments(string contents)
+        {
+            if (string.IsNullOrWhiteSpace(contents))
+                return contents;
+
+            contents += Environment.NewLine;
+
+            //https://stackoverflow.com/a/3524689
+            var blockComments = @"/\*(.*?)\*/";
+            var lineComments = @"//(.*?)\r?\n";
+            var strings = @"""((\\[^\n]|[^""\n])*)""";
+            var verbatimStrings = @"@(""[^""]*"")+";
+
+            string noComments = Regex.Replace(contents, blockComments + "|" + lineComments + "|" + strings + "|" + verbatimStrings, me =>
+            {
+                if (me.Value.StartsWith("/*") || me.Value.StartsWith("//"))
+                    return me.Value.StartsWith("//") ? Environment.NewLine : "";
+                // Keep the literal strings
+                return me.Value;
+            }, RegexOptions.Singleline);
+
+            return noComments;
+        }
+    }
+}

--- a/WhenTheVersion/Program.cs
+++ b/WhenTheVersion/Program.cs
@@ -2,14 +2,17 @@
 using System.IO;
 using System.Diagnostics;
 
-namespace WhatTheVersion {
+namespace WhenTheVersion
+{
 
-    class Program {
+    class Program
+    {
 
-        const string DayPlaceholder      = "{DD}";
-        const string MonthPlaceholder    = "{MM}";
-        const string YearPlaceholder     = "{YYYY}";
-        const string SVNPlaceholder      = "{SVN}";
+        const string DayPlaceholder = "{DD}";
+        const string MonthPlaceholder = "{MM}";
+        const string YearPlaceholder = "{YYYY}";
+        const string SVNPlaceholder = "{SVN}";
+        const string AutoIncrementPlaceholder = "{AUTO}";
         const string SubWCrevPlaceholder = "$WCREV$";
 
 
@@ -23,7 +26,8 @@ namespace WhatTheVersion {
         /// path-to-SubWCrev.exe (optional)
         /// svn-working-copy-path (required if path-to-SubWCrev.exe is given)
         /// </summary>
-        static int Main(string[] args) {
+        static int Main(string[] args)
+        {
 
             // is the usage correct?
             if (!(args.Length == 2 || args.Length == 4))
@@ -36,28 +40,37 @@ namespace WhatTheVersion {
 
 
             // read the input file
-            try {
-                inputFileContents = File.ReadAllText(args[0]);
-            } catch (Exception) {
+            try
+            {
+                inputFileContents = File.ReadAllText(args[ArgumentIndex.InputFile]);
+            }
+            catch (Exception exc)
+            {
+                WriteErrorMessageToConsole(exc.Message);
                 return PrintUsage(ExitCode.WTV_Problem_Reading_Input_File);
             }
 
-            
+
             // do the replacements
-            try {
+            try
+            {
                 outputFileContents = DoReplacements(inputFileContents, args);
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 return PrintUsage(ExitCode.WTV_Problem_Doing_Replacements);
             }
-            
+
 
             // write out
-            try	{
-		        File.WriteAllText(args[1], outputFileContents);
-	        }
-	        catch (Exception) {
+            try
+            {
+                File.WriteAllText(args[ArgumentIndex.OutputFile], outputFileContents);
+            }
+            catch (Exception)
+            {
                 return PrintUsage(ExitCode.WTV_Problem_Writing_To_Output_File);
-	        }
+            }
 
 
             // done
@@ -69,14 +82,24 @@ namespace WhatTheVersion {
         /// <summary>
         /// Replaces the Date and SVN placeholders with the actual values
         /// </summary>
-        private static string DoReplacements(string inputFileContents, string[] args) {
+        private static string DoReplacements(string inputFileContents, string[] args)
+        {
             DateTime now = DateTime.UtcNow;
 
-            return inputFileContents
-                .Replace(DayPlaceholder, now.Day.ToString())
-                .Replace(MonthPlaceholder, now.Month.ToString())
-                .Replace(YearPlaceholder, now.Year.ToString())
-                .Replace(SVNPlaceholder, GetSVNRevisionNumber(args).ToString());
+
+            var updatedContents = inputFileContents
+                                                    .Replace(DayPlaceholder, now.Day.ToString())
+                                                    .Replace(MonthPlaceholder, now.Month.ToString())
+                                                    .Replace(YearPlaceholder, now.Year.ToString())
+                                                    .Replace(SVNPlaceholder, GetSVNRevisionNumber(args).ToString());
+
+            var revisionInfo = GetRevisionInfo(inputFileContents, args);
+            if (revisionInfo == null) return updatedContents;
+
+            if (revisionInfo.Succeed == false)
+                WriteErrorMessageToConsole(revisionInfo.ErrorIfAny);
+
+            return updatedContents.Replace(AutoIncrementPlaceholder, revisionInfo.NextRevisionNumber.ToString());
         }
 
 
@@ -87,34 +110,42 @@ namespace WhatTheVersion {
         /// <remarks>
         /// Always returns a value, but writes errors to the Console (returning 0)
         /// </remarks>
-        private static ushort GetSVNRevisionNumber(string[] args) {
+        private static ushort GetSVNRevisionNumber(string[] args)
+        {
             ushort svnRevisionNumber = 0;
 
-            if (args.Length == 4) {
+            if (args.Length == 4)
+            {
 
                 // is the given path to SubWCrev.exe OK?
-                if (!File.Exists(args[2])) {
+                if (!File.Exists(args[ArgumentIndex.SubWCRev]))
+                {
                     // hmm, file doesn't exist, is this an environment variable containing the path instead?
-                    try {	        
-		                args[2] = Environment.GetEnvironmentVariable(args[2]);
-	                }
-	                catch (Exception) {	/* exception doesn't matter */ }
+                    try
+                    {
+                        args[ArgumentIndex.SubWCRev] = Environment.GetEnvironmentVariable(args[ArgumentIndex.SubWCRev]);
+                    }
+                    catch (Exception)
+                    { /* exception doesn't matter */
+                    }
                 }
 
                 // try again in case we've found an environment variable..
-                if (!File.Exists(args[2])) {
-                    WriteErrorMessageToConsole("SubWCrev.exe not found at: " + args[2]);
+                if (!File.Exists(args[ArgumentIndex.SubWCRev]))
+                {
+                    WriteErrorMessageToConsole("SubWCrev.exe not found at: " + args[ArgumentIndex.SubWCRev]);
                     return svnRevisionNumber;
                 }
 
                 // do the call to SubWCRev.exe..
-                try {	        
-		            svnRevisionNumber = CallSubWCrev(args);
-	            } catch (Exception ex) {
-		            WriteErrorMessageToConsole(ex.Message);
-	            }
-
-
+                try
+                {
+                    svnRevisionNumber = CallSubWCrev(args);
+                }
+                catch (Exception ex)
+                {
+                    WriteErrorMessageToConsole(ex.Message);
+                }
             }
 
             return svnRevisionNumber;
@@ -127,26 +158,29 @@ namespace WhatTheVersion {
         /// Calls SubWCRev.exe to get the Subversion Working Copy Revision number
         /// </summary>
         /// <returns></returns>
-        private static ushort CallSubWCrev(string[] args) {
+        private static ushort CallSubWCrev(string[] args)
+        {
             ushort svnRevisionNumber = 0;
 
             // create a temporary file call SubWCrev.exe on
             string tempFilename = Path.GetTempFileName();
 
-            try {
+            try
+            {
 
                 File.WriteAllText(tempFilename, SubWCrevPlaceholder);
 
 
                 // make sure working copy path is enclosed in quotes
                 //  in case the path contains spaces..
-                string workingCopyPath = args[3].StartsWith("\"")
-                    ? args[3] : "\"" + args[3] + "\"";
+                string workingCopyPath = args[ArgumentIndex.SVNWorkingCopy].StartsWith("\"")
+                    ? args[ArgumentIndex.SVNWorkingCopy] : "\"" + args[ArgumentIndex.SVNWorkingCopy] + "\"";
 
                 // call SubWCrev.exe on our temporary file
                 ProcessStartInfo subWCrevProcessInfo = new ProcessStartInfo(
-                    args[2],
-                    workingCopyPath + " \"" + tempFilename + "\" \"" + tempFilename + "\"") { CreateNoWindow = true };
+                    args[ArgumentIndex.SubWCRev],
+                    workingCopyPath + " \"" + tempFilename + "\" \"" + tempFilename + "\"")
+                { CreateNoWindow = true };
 
                 Process subWCrevProcessCall = Process.Start(subWCrevProcessInfo);
                 subWCrevProcessCall.WaitForExit();
@@ -156,7 +190,8 @@ namespace WhatTheVersion {
                 // did it work?
                 //  SubWCRev.exe error codes:
                 //  source: http://code.google.com/p/tortoisesvn/source/browse/trunk/src/SubWCRev/SubWCRev.cpp
-                switch (subWCrevProcessCall.ExitCode) {
+                switch (subWCrevProcessCall.ExitCode)
+                {
                     case 0:
                         // Call completed OK
 
@@ -208,18 +243,26 @@ namespace WhatTheVersion {
                     default:
                         throw new ArgumentException("SubWCRev.exe - unknown exit code status (sorry!)");
 
-	            }
+                }
 
 
-            } catch (ArgumentException) {
+            }
+            catch (ArgumentException)
+            {
                 throw;
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 throw new ArgumentException("Problem running SubWCrev.exe", ex);
-            } finally {
+            }
+            finally
+            {
                 // tidy up
-                try {
+                try
+                {
                     File.Delete(tempFilename);
-                } catch (Exception) { }
+                }
+                catch (Exception) { }
 
             }
 
@@ -232,7 +275,8 @@ namespace WhatTheVersion {
         /// Writes an error message to the Console
         /// </summary>
         /// <param name="message"></param>
-        private static void WriteErrorMessageToConsole(string message) {
+        private static void WriteErrorMessageToConsole(string message)
+        {
             ConsoleColor originalColor = Console.ForegroundColor;
 
             Console.WriteLine("");
@@ -252,7 +296,8 @@ namespace WhatTheVersion {
         /// <summary>
         /// Prints usage instructions to the Console, and returns the int value for the ExitCode passed in
         /// </summary>
-        private static int PrintUsage(ExitCode exitCode) {
+        private static int PrintUsage(ExitCode exitCode)
+        {
             ConsoleColor originalColor = Console.ForegroundColor;
 
             Console.WriteLine("");
@@ -271,6 +316,7 @@ namespace WhatTheVersion {
             Console.WriteLine("     {MM}    - Month");
             Console.WriteLine("     {YYYY}  - Year");
             Console.WriteLine("     {SVN}   - SubVersion revision (must specify the path to SubWCrev.exe and working copy path)");
+            Console.WriteLine("     {AUTO}  - Will read the existing Build number from the file and will increment it by 1");
             Console.WriteLine("");
             Console.WriteLine("  Example Pre-Build command: (remove the line breaks)");
             Console.WriteLine("    \"C:\\Path\\To\\WTV.exe\"");
@@ -279,10 +325,23 @@ namespace WhatTheVersion {
             Console.WriteLine("      \"C:\\Program Files\\TortoiseSVN\\bin\\SubWCRev.exe\"");
             Console.WriteLine("      \"$(SolutionDir).\"");
 
+            Console.WriteLine("  Example Pre-Build command: (remove the line breaks)");
+            Console.WriteLine("    \"C:\\Path\\To\\WTV.exe\"");
+            Console.WriteLine("      \"$(ProjectDir)Properties\\AssemblyInfo.Template.cs\"");
+            Console.WriteLine("      \"$(ProjectDir)Properties\\AssemblyInfo.cs\"");
+            Console.WriteLine("      \"SubWCRev.exe\"");
+            Console.WriteLine("      \"$(SolutionDir).\"");
+
             return (int)exitCode;
         }
 
+        private static RevisionInfo GetRevisionInfo(string inputFileContents, string[] args)
+        {
+            if (inputFileContents.IndexOf(AutoIncrementPlaceholder) == -1)
+                return null;
 
+            return new AssemblyInfoReader(args[ArgumentIndex.OutputFile]).GetRevisionInfo();
+        }
 
 
 
@@ -290,7 +349,8 @@ namespace WhatTheVersion {
         /// <summary>
         /// Enumeration for exit / return codes
         /// </summary>
-        enum ExitCode : int {
+        enum ExitCode : int
+        {
             Success = 0,
             WTV_Wrong_No_Of_Arguments = 1,
             WTV_Problem_Reading_Input_File = 2,
@@ -300,6 +360,13 @@ namespace WhatTheVersion {
 
         }
 
+        static class ArgumentIndex
+        {
+            public const int InputFile = 0;
+            public const int OutputFile = 1;
+            public const int SubWCRev = 2;
+            public const int SVNWorkingCopy = 3;
+        }
 
     }
 }

--- a/WhenTheVersion/RevisionInfo.cs
+++ b/WhenTheVersion/RevisionInfo.cs
@@ -1,0 +1,19 @@
+﻿namespace WhenTheVersion
+{
+    public class RevisionInfo
+    {
+        public RevisionInfo(int revisionNumber, int nextRevisionNumber, string errorIfAny = null)
+        {
+            RevisionNumber = revisionNumber;
+            NextRevisionNumber = nextRevisionNumber;
+            ErrorIfAny = errorIfAny;
+        }
+
+        public int RevisionNumber { get; }
+        public int NextRevisionNumber { get; }
+        public string ErrorIfAny { get; set; }
+        public bool Succeed => string.IsNullOrWhiteSpace(ErrorIfAny);
+
+        public override string ToString() => Succeed ? $"RevisionNumber: {RevisionNumber}, NextRevisionNumber: {NextRevisionNumber}" : ErrorIfAny;
+    }
+}

--- a/WhenTheVersion/WhenTheVersion.csproj
+++ b/WhenTheVersion/WhenTheVersion.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WhenTheVersion</RootNamespace>
     <AssemblyName>WTV</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>wtv.ico</ApplicationIcon>
@@ -40,17 +42,21 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>bin\Debug\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>bin\Release\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfoReader.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RevisionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/WhenTheVersion/app.config
+++ b/WhenTheVersion/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v2.0.50727"/>
-  </startup>
+    
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup>
 </configuration>


### PR DESCRIPTION
Hi,

I hope you don't mind adding one more feature to this tool.

Use case:
I wanted to use the date and auto-incrementing revision number so something like the following line:
`[assembly: AssemblyVersion("{YYYY}.{MM}.{DD}.{AUTO}")]`

I noticed code already supports {SVN} so I added one more to this {AUTO}. Please take a look.

I have also added test cases and ensured that they all pass. I know I can merge my code directly to your trunk but I think it would be best to give you the option to look at the code before the code is merged.

Thanks,
Nimesh Dhruve
